### PR TITLE
Fixed path to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Contents
 
- - **/docker-compose.yml**: used to orchestrate the Dockerfiles
+ - **/docker/docker-compose.yml**: used to orchestrate the Dockerfiles
  - **/etc:** Dockerfiles and their configurations.
  - **/var/www**: Your web files live here.
 


### PR DESCRIPTION
The readme doc mentions 'docker-compose.yml' in the Contents section. The real file is in the 'docker' folder.
